### PR TITLE
Implemented parentdir check in locate.sh

### DIFF
--- a/pre_commit_hooks/helpers/locate.sh
+++ b/pre_commit_hooks/helpers/locate.sh
@@ -12,10 +12,14 @@ prefixed_local_command="php $local_command"
 
 if [ -f "$vendor_command" ]; then
     exec_command=$vendor_command
+if [ -f "../$vendor_command" ]; then
+    exec_command="../"+$vendor_command
 elif hash $global_command 2>/dev/null; then
     exec_command=$global_command
 elif [ -f "$local_command" ]; then
     exec_command=$prefixed_local_command
+elif [ -f "../$local_command" ]; then
+    exec_command="../"+$prefixed_local_command
 else
     echo -e "${bldred}No valid ${title} found!${txtrst}"
     echo "Please have one available as one of the following:"


### PR DESCRIPTION
Created necessary changes to check parent directories as well as root. Note, I kept the original check as ordino-skeleton will have vendor as a sub-directory, not at path `../vendor`

Resolves #1